### PR TITLE
Add StartCommand and use Filesystem

### DIFF
--- a/src/Console/Commands/LayerCommand.php
+++ b/src/Console/Commands/LayerCommand.php
@@ -3,6 +3,7 @@
 namespace Xefi\LaravelOSDD\Console\Commands;
 
 use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Console\Attribute\AsCommand;
 
 use function Laravel\Prompts\multiselect;
@@ -25,6 +26,20 @@ class LayerCommand extends Command
         'src/Policies',
         'src/Providers',
     ];
+
+    /**
+     * The filesystem instance.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $files;
+
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+
+        $this->files = $files;
+    }
 
     public function handle(): int
     {
@@ -94,7 +109,7 @@ class LayerCommand extends Command
         foreach ($components as $component) {
             $componentPath = $layerPath . '/' . $component;
 
-            mkdir($componentPath, recursive: true);
+            $this->files->makeDirectory($componentPath, 0755, true, true);
 
             if ($component === 'src/Providers') {
                 $this->createFile(
@@ -103,7 +118,7 @@ class LayerCommand extends Command
                     ['{{ namespace }}' => $namespace, '{{ class }}' => $serviceProviderClass],
                 );
             } else {
-                touch($componentPath . '/.gitkeep');
+                $this->files->put($componentPath . '/.gitkeep', '');
             }
         }
     }
@@ -112,16 +127,16 @@ class LayerCommand extends Command
     {
         $directory = dirname($path);
 
-        if (!is_dir($directory)) {
-            mkdir($directory, recursive: true);
+        if (!$this->files->isDirectory($directory)) {
+            $this->files->makeDirectory($directory, 0755, true, true);
         }
 
-        file_put_contents($path, str_replace(array_keys($replacements), array_values($replacements), $contents));
+        $this->files->put($path, str_replace(array_keys($replacements), array_values($replacements), $contents));
     }
 
     private function resolveStub(string $stub): string
     {
-        return file_get_contents(__DIR__ . '/../stubs/layer/' . $stub . '.stub');
+        return $this->files->get(__DIR__ . '/../stubs/layer/' . $stub . '.stub');
     }
 
     private function toNamespace(string $vendor, string $package): string

--- a/src/Console/Commands/StartCommand.php
+++ b/src/Console/Commands/StartCommand.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace Xefi\LaravelOSDD\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Console\Attribute\AsCommand;
+
+#[AsCommand(name: 'osdd:start')]
+class StartCommand extends Command
+{
+    protected $name = 'osdd:start';
+
+    protected $description = 'Prepare a fresh Laravel project for OSDD';
+
+    private const LAYER_NAME = 'functional/users';
+    private const LAYER_NAMESPACE = 'Functional\\Users';
+
+    /**
+     * The filesystem instance.
+     */
+    protected Filesystem $files;
+
+    public function __construct(Filesystem $files)
+    {
+        parent::__construct();
+
+        $this->files = $files;
+    }
+
+    public function handle(): int
+    {
+        $layerPath = $this->resolveLayerBasePath() . '/users';
+
+        $this->createUsersLayer($layerPath);
+        $this->moveUserModel($layerPath);
+        $this->moveUserFactory($layerPath);
+        $this->moveUserMigrations($layerPath);
+        $this->deleteAppDirectory();
+
+        $this->components->info('Congratulations! Your project is ready for OSDD. Create your first layer with <options=bold>php artisan osdd:layer</>.');
+
+        return self::SUCCESS;
+    }
+
+    private function resolveLayerBasePath(): string
+    {
+        $paths = config('osdd.layers.paths', []);
+
+        return $paths['functional'] ?? $this->laravel->basePath('functional');
+    }
+
+    private function createUsersLayer(string $layerPath): void
+    {
+        $components = [
+            'database/migrations',
+            'database/factories',
+            'database/seeders',
+            'src/Models',
+            'src/Factories',
+            'src/Policies',
+            'src/Providers',
+        ];
+
+        $this->createFile(
+            $layerPath . '/composer.json',
+            $this->resolveStub('composer'),
+            [
+                '{{ name }}' => self::LAYER_NAME,
+                '{{ namespace }}' => str_replace('\\', '\\\\', self::LAYER_NAMESPACE),
+            ],
+        );
+
+        foreach ($components as $component) {
+            $componentPath = $layerPath . '/' . $component;
+
+            $this->files->makeDirectory($componentPath, 0755, true, true);
+
+            if ($component === 'src/Providers') {
+                $this->createFile(
+                    $componentPath . '/UsersServiceProvider.php',
+                    $this->resolveStub('service-provider'),
+                    ['{{ namespace }}' => self::LAYER_NAMESPACE, '{{ class }}' => 'UsersServiceProvider'],
+                );
+            } else {
+                $this->files->put($componentPath . '/.gitkeep', '');
+            }
+        }
+
+        $this->components->info('Layer <options=bold>' . self::LAYER_NAME . '</> created at <options=bold>' . $layerPath . '</>.');
+    }
+
+    private function moveUserModel(string $layerPath): void
+    {
+        $source = $this->laravel->basePath('app/Models/User.php');
+
+        if (!$this->files->isFile($source)) {
+            $this->components->warn('No User model found at app/Models/User.php, skipping.');
+            return;
+        }
+
+        $contents = str_replace(
+            [
+                'namespace App\\Models;',
+                '@use HasFactory<\\Database\\Factories\\UserFactory>',
+            ],
+            [
+                'namespace Functional\\Users\\Models;',
+                '@use HasFactory<\\Functional\\Users\\Database\\Factories\\UserFactory>',
+            ],
+            $this->files->get($source),
+        );
+
+        $this->files->put($layerPath . '/src/Models/User.php', $contents);
+
+        $this->components->info('Moved User model to layer.');
+    }
+
+    private function moveUserFactory(string $layerPath): void
+    {
+        $source = $this->laravel->basePath('database/factories/UserFactory.php');
+
+        if (!$this->files->isFile($source)) {
+            $this->components->warn('No UserFactory found at database/factories/UserFactory.php, skipping.');
+            return;
+        }
+
+        $contents = str_replace(
+            [
+                'namespace Database\\Factories;',
+                'use App\\Models\\User;',
+            ],
+            [
+                'namespace Functional\\Users\\Database\\Factories;',
+                'use Functional\\Users\\Models\\User;',
+            ],
+            $this->files->get($source),
+        );
+
+        $this->files->put($layerPath . '/database/factories/UserFactory.php', $contents);
+
+        $this->components->info('Moved UserFactory to layer.');
+    }
+
+    private function moveUserMigrations(string $layerPath): void
+    {
+        $migrationsPath = $this->laravel->basePath('database/migrations');
+        $migrations = $this->files->glob($migrationsPath . '/*_create_users_table.php') ?: [];
+
+        if (empty($migrations)) {
+            $this->components->warn('No user migrations found, skipping.');
+            return;
+        }
+
+        foreach ($migrations as $migration) {
+            $this->files->move($migration, $layerPath . '/database/migrations/' . basename($migration));
+        }
+
+        $this->components->info('Moved ' . count($migrations) . ' user migration(s) to layer.');
+    }
+
+    private function deleteAppDirectory(): void
+    {
+        $appPath = $this->laravel->basePath('app');
+
+        if (!$this->files->isDirectory($appPath)) {
+            $this->components->warn('No app/ directory found, skipping.');
+            return;
+        }
+
+        $this->files->deleteDirectory($appPath);
+
+        $this->components->info('Deleted app/ directory.');
+    }
+
+    private function createFile(string $path, string $contents, array $replacements = []): void
+    {
+        $directory = dirname($path);
+
+        if (!$this->files->isDirectory($directory)) {
+            $this->files->makeDirectory($directory, 0755, true, true);
+        }
+
+        $this->files->put($path, str_replace(array_keys($replacements), array_values($replacements), $contents));
+    }
+
+    private function resolveStub(string $stub): string
+    {
+        return $this->files->get(__DIR__ . '/../stubs/layer/' . $stub . '.stub');
+    }
+}

--- a/src/LaravelOSDDServiceProvider.php
+++ b/src/LaravelOSDDServiceProvider.php
@@ -5,6 +5,7 @@ namespace Xefi\LaravelOSDD;
 use Illuminate\Support\ServiceProvider;
 use Xefi\LaravelOSDD\Console\Commands\Make\FactoryMakeCommand;
 use Xefi\LaravelOSDD\Console\Commands\LayerCommand;
+use Xefi\LaravelOSDD\Console\Commands\StartCommand;
 
 class LaravelOSDDServiceProvider extends ServiceProvider
 {
@@ -16,6 +17,7 @@ class LaravelOSDDServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->commands([
                 LayerCommand::class,
+                StartCommand::class,
                 FactoryMakeCommand::class,
             ]);
         }

--- a/src/Layers/Layer.php
+++ b/src/Layers/Layer.php
@@ -2,6 +2,7 @@
 
 namespace Xefi\LaravelOSDD\Layers;
 
+use Illuminate\Filesystem\Filesystem;
 use Symfony\Component\Finder\SplFileInfo;
 
 class Layer
@@ -23,7 +24,7 @@ class Layer
     {
         $composerPath = $directory->getRealPath() . '/composer.json';
 
-        if (!is_file($composerPath)) {
+        if (!app(Filesystem::class)->isFile($composerPath)) {
             return false;
         }
 

--- a/src/Layers/LayerManifest.php
+++ b/src/Layers/LayerManifest.php
@@ -2,13 +2,15 @@
 
 namespace Xefi\LaravelOSDD\Layers;
 
+use Illuminate\Filesystem\Filesystem;
+
 class LayerManifest
 {
     private function __construct(private readonly array $data) {}
 
     public static function fromPath(string $path): self
     {
-        return new self(json_decode(file_get_contents($path), true, 512, JSON_THROW_ON_ERROR));
+        return new self(json_decode(app(Filesystem::class)->get($path), true, 512, JSON_THROW_ON_ERROR));
     }
 
     public function name(): string

--- a/tests/Console/Commands/StartCommandTest.php
+++ b/tests/Console/Commands/StartCommandTest.php
@@ -1,0 +1,235 @@
+<?php
+
+namespace Xefi\LaravelOSDD\Tests\Console\Commands;
+
+use Illuminate\Filesystem\Filesystem;
+use Xefi\LaravelOSDD\Tests\TestCase;
+
+class StartCommandTest extends TestCase
+{
+    protected string $projectPath;
+
+    protected function getEnvironmentSetUp($app): void
+    {
+        $this->projectPath = sys_get_temp_dir() . '/osdd-start-test-' . uniqid();
+        mkdir($this->projectPath, 0755, true);
+
+        $app->setBasePath($this->projectPath);
+
+        $app['config']->set('osdd.layers.paths', [
+            'functional' => $this->projectPath . '/functional',
+        ]);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        mkdir($this->projectPath . '/app/Models', 0755, true);
+        file_put_contents($this->projectPath . '/app/Models/User.php', $this->fakeUserModel());
+
+        mkdir($this->projectPath . '/database/factories', 0755, true);
+        file_put_contents($this->projectPath . '/database/factories/UserFactory.php', $this->fakeUserFactory());
+
+        mkdir($this->projectPath . '/database/migrations', 0755, true);
+        file_put_contents($this->projectPath . '/database/migrations/0001_01_01_000000_create_users_table.php', $this->fakeUserMigration());
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        (new Filesystem)->deleteDirectory($this->projectPath);
+    }
+
+    public function testItCreatesTheUsersLayer(): void
+    {
+        $this->artisan('osdd:start')->assertExitCode(0);
+
+        $this->assertFileExists($this->projectPath . '/functional/users/composer.json');
+        $this->assertFileExists($this->projectPath . '/functional/users/src/Providers/UsersServiceProvider.php');
+        $this->assertFileExists($this->projectPath . '/functional/users/database/migrations/.gitkeep');
+        $this->assertFileExists($this->projectPath . '/functional/users/database/factories/.gitkeep');
+        $this->assertFileExists($this->projectPath . '/functional/users/database/seeders/.gitkeep');
+        $this->assertFileExists($this->projectPath . '/functional/users/src/Models/.gitkeep');
+        $this->assertFileExists($this->projectPath . '/functional/users/src/Factories/.gitkeep');
+        $this->assertFileExists($this->projectPath . '/functional/users/src/Policies/.gitkeep');
+    }
+
+    public function testItCreatesTheUsersLayerComposerJson(): void
+    {
+        $this->artisan('osdd:start')->assertExitCode(0);
+
+        $contents = file_get_contents($this->projectPath . '/functional/users/composer.json');
+
+        $this->assertStringContainsString('"name": "functional/users"', $contents);
+        $this->assertStringContainsString('"type": "layer"', $contents);
+        $this->assertStringContainsString('"Functional\\\\Users\\\\": "src/"', $contents);
+    }
+
+    public function testItCreatesTheUsersServiceProvider(): void
+    {
+        $this->artisan('osdd:start')->assertExitCode(0);
+
+        $contents = file_get_contents($this->projectPath . '/functional/users/src/Providers/UsersServiceProvider.php');
+
+        $this->assertStringContainsString('namespace Functional\Users\Providers;', $contents);
+        $this->assertStringContainsString('class UsersServiceProvider extends ServiceProvider', $contents);
+        $this->assertStringContainsString("loadMigrationsFrom(__DIR__ . '/../../database/migrations')", $contents);
+    }
+
+    public function testItMovesTheUserModelWithCorrectNamespace(): void
+    {
+        $this->artisan('osdd:start')->assertExitCode(0);
+
+        $this->assertFileExists($this->projectPath . '/functional/users/src/Models/User.php');
+
+        $contents = file_get_contents($this->projectPath . '/functional/users/src/Models/User.php');
+
+        $this->assertStringContainsString('namespace Functional\Users\Models;', $contents);
+        $this->assertStringContainsString('class User extends Authenticatable', $contents);
+    }
+
+    public function testItUpdatesTheUserModelHasFactoryDocblock(): void
+    {
+        $this->artisan('osdd:start')->assertExitCode(0);
+
+        $contents = file_get_contents($this->projectPath . '/functional/users/src/Models/User.php');
+
+        $this->assertStringContainsString('@use HasFactory<\Functional\Users\Database\Factories\UserFactory>', $contents);
+    }
+
+    public function testItMovesTheUserFactoryWithCorrectNamespace(): void
+    {
+        $this->artisan('osdd:start')->assertExitCode(0);
+
+        $this->assertFileExists($this->projectPath . '/functional/users/database/factories/UserFactory.php');
+
+        $contents = file_get_contents($this->projectPath . '/functional/users/database/factories/UserFactory.php');
+
+        $this->assertStringContainsString('namespace Functional\Users\Database\Factories;', $contents);
+        $this->assertStringContainsString('use Functional\Users\Models\User;', $contents);
+        $this->assertStringContainsString('class UserFactory extends Factory', $contents);
+    }
+
+    public function testItMovesUserMigrationsToLayer(): void
+    {
+        $this->artisan('osdd:start')->assertExitCode(0);
+
+        $this->assertFileExists($this->projectPath . '/functional/users/database/migrations/0001_01_01_000000_create_users_table.php');
+        $this->assertFileDoesNotExist($this->projectPath . '/database/migrations/0001_01_01_000000_create_users_table.php');
+    }
+
+    public function testItDeletesTheAppDirectory(): void
+    {
+        $this->artisan('osdd:start')->assertExitCode(0);
+
+        $this->assertDirectoryDoesNotExist($this->projectPath . '/app');
+    }
+
+    public function testItSkipsUserModelGracefullyWhenMissing(): void
+    {
+        unlink($this->projectPath . '/app/Models/User.php');
+
+        $this->artisan('osdd:start')->assertExitCode(0);
+
+        $this->assertFileDoesNotExist($this->projectPath . '/functional/users/src/Models/User.php');
+    }
+
+    public function testItSkipsUserFactoryGracefullyWhenMissing(): void
+    {
+        unlink($this->projectPath . '/database/factories/UserFactory.php');
+
+        $this->artisan('osdd:start')->assertExitCode(0);
+
+        $this->assertFileDoesNotExist($this->projectPath . '/functional/users/database/factories/UserFactory.php');
+    }
+
+    public function testItSkipsUserMigrationsGracefullyWhenMissing(): void
+    {
+        unlink($this->projectPath . '/database/migrations/0001_01_01_000000_create_users_table.php');
+
+        $this->artisan('osdd:start')->assertExitCode(0);
+
+        $this->assertFileDoesNotExist($this->projectPath . '/functional/users/database/migrations/0001_01_01_000000_create_users_table.php');
+    }
+
+    public function testItUsesTheConfiguredFunctionalPath(): void
+    {
+        $custom = $this->projectPath . '/layers/functional';
+        $this->app['config']->set('osdd.layers.paths', ['functional' => $custom]);
+
+        $this->artisan('osdd:start')->assertExitCode(0);
+
+        $this->assertFileExists($custom . '/users/composer.json');
+    }
+
+    // -------------------------------------------------------------------------
+
+    private function fakeUserModel(): string
+    {
+        return <<<'PHP'
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+
+class User extends Authenticatable
+{
+    /** @use HasFactory<\Database\Factories\UserFactory> */
+    use HasFactory, Notifiable;
+}
+PHP;
+    }
+
+    private function fakeUserFactory(): string
+    {
+        return <<<'PHP'
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class UserFactory extends Factory
+{
+    protected $model = User::class;
+
+    public function definition(): array
+    {
+        return ['name' => fake()->name()];
+    }
+}
+PHP;
+    }
+
+    private function fakeUserMigration(): string
+    {
+        return <<<'PHP'
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('users');
+    }
+};
+PHP;
+    }
+}


### PR DESCRIPTION
Introduce a new osdd:start console command (StartCommand) to scaffold a functional/users layer by moving User model, factory and migrations and removing the app/ directory. Register the command in the service provider and add comprehensive tests (StartCommandTest). Refactor file operations to use Illuminate\Filesystem\Filesystem: inject Filesystem into LayerCommand and StartCommand, replace direct mkdir/touch/file_get_contents/file_put_contents with Filesystem methods, and update Layer and LayerManifest to use the Filesystem via app(). This centralizes filesystem access and improves testability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `osdd:start` command to automate project bootstrapping and functional layer setup.
  * Command initializes users layer, generates service provider, and migrates existing user models, factories, and migrations into the new structure.

* **Refactor**
  * Integrated Laravel filesystem abstraction across core components for improved consistency and testability.

* **Tests**
  * Added comprehensive test suite for the new start command validating layer creation, file migration, and namespace updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->