### PR TITLE
Add Packagist deploy workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,12 +5,11 @@ on:
     types: [created]
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
 
     permissions:
       contents: read
-      packages: write
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Add a GitHub Actions workflow that triggers on release creation to update Packagist. The job runs on ubuntu-latest, checks out the repo and invokes mnavarrocarter/packagist-update with the Packagist username (GautierDele) and the api token from secrets.PACKAGIST_TOKEN; permissions set for contents: read and packages: write.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adds automated package publishing on release creation: releases now trigger a workflow that publishes package metadata to the package registry using stored credentials.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->