### PR TITLE
Resolve layer in interact() hook

### DIFF
--- a/src/Console/Commands/Make/ChoosesOsddLayer.php
+++ b/src/Console/Commands/Make/ChoosesOsddLayer.php
@@ -2,7 +2,9 @@
 
 namespace Xefi\LaravelOSDD\Console\Commands\Make;
 
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
 use Xefi\LaravelOSDD\Layers\Layer;
 use Xefi\LaravelOSDD\Layers\LayersCollection;
 
@@ -42,10 +44,8 @@ trait ChoosesOsddLayer
         return $this->resolvedLayer = $layers->first(fn(Layer $l) => $l->manifest->name() === $chosen);
     }
 
-    protected function interact(
-        \Symfony\Component\Console\Input\InputInterface $input,
-        \Symfony\Component\Console\Output\OutputInterface $output,
-    ): void {
+    protected function interact(InputInterface $input, OutputInterface $output): void
+    {
         $this->resolveLayer();
 
         parent::interact($input, $output);


### PR DESCRIPTION
Add an interact() method to the ChoosesOsddLayer trait that calls resolveLayer() and then delegates to parent::interact(). This ensures the layer is resolved before any interactive prompts run during the Symfony Console command interaction phase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal command interaction flow with enhanced layer resolution handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->