### PR TITLE
Reset bootstrap providers to empty array

### DIFF
--- a/src/Console/Commands/StartCommand.php
+++ b/src/Console/Commands/StartCommand.php
@@ -126,9 +126,7 @@ class StartCommand extends Command
             return;
         }
 
-        $this->files->put($path, "<?php\n\nreturn [\n    Technical\\Osdd\\Providers\\OsddServiceProvider::class,\n];\n");
-
-        $this->components->info('Registered OsddServiceProvider in bootstrap/providers.php.');
+        $this->files->put($path, "<?php\n\nreturn [\n];\n");
     }
 
     private function cleanComposerAutoload(): void

--- a/tests/Console/Commands/StartCommandTest.php
+++ b/tests/Console/Commands/StartCommandTest.php
@@ -194,7 +194,7 @@ class StartCommandTest extends TestCase
         $this->assertFileExists($custom . '/users/composer.json');
     }
 
-    public function testItInjectsOsddServiceProviderInBootstrapProviders(): void
+    public function testItResetsBootstrapProvidersToEmptyArray(): void
     {
         $this->artisan('osdd:start')
             ->expectsConfirmation('Run composer update now?', 'no')
@@ -203,8 +203,8 @@ class StartCommandTest extends TestCase
         $contents = file_get_contents($this->projectPath . '/bootstrap/providers.php');
 
         $this->assertStringNotContainsString('AppServiceProvider', $contents);
-        $this->assertStringContainsString('OsddServiceProvider::class', $contents);
-        $this->assertStringContainsString('Technical\\Osdd\\Providers\\OsddServiceProvider', $contents);
+        $this->assertStringNotContainsString('OsddServiceProvider', $contents);
+        $this->assertStringContainsString('return [', $contents);
     }
 
     public function testItSkipsBootstrapProvidersGracefullyWhenMissing(): void


### PR DESCRIPTION
StartCommand now overwrites bootstrap/providers.php with an empty array instead of injecting Technical\Osdd\Providers\OsddServiceProvider and the informational message was removed. Tests updated to reflect the new behavior: the providers file should be reset to an empty array and must not contain any OsddServiceProvider references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Simplified the application startup process by resetting service provider configuration to its default state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->