### PR TITLE
Register tinker aliases; refactor service provider

### DIFF
--- a/src/LaravelOSDDServiceProvider.php
+++ b/src/LaravelOSDDServiceProvider.php
@@ -3,104 +3,159 @@
 namespace Xefi\LaravelOSDD;
 
 use Illuminate\Support\ServiceProvider;
-use Xefi\LaravelOSDD\Console\Commands\Make\ControllerMakeCommand;
-use Xefi\LaravelOSDD\Console\Commands\Make\FactoryMakeCommand;
-use Xefi\LaravelOSDD\Console\Commands\Make\MigrateMakeCommand;
-use Xefi\LaravelOSDD\Console\Commands\Make\ModelMakeCommand;
-use Xefi\LaravelOSDD\Console\Commands\Make\PolicyMakeCommand;
-use Xefi\LaravelOSDD\Console\Commands\Make\RequestMakeCommand;
-use Xefi\LaravelOSDD\Console\Commands\Make\SeederMakeCommand;
-use Xefi\LaravelOSDD\Console\Commands\Make\ServiceProviderMakeCommand;
-use Xefi\LaravelOSDD\Console\Commands\Make\TestMakeCommand;
+use Symfony\Component\Finder\Finder;
+use Xefi\LaravelOSDD\Console\Commands\LayerCommand;
 use Xefi\LaravelOSDD\Console\Commands\Make\CastMakeCommand;
 use Xefi\LaravelOSDD\Console\Commands\Make\ChannelMakeCommand;
 use Xefi\LaravelOSDD\Console\Commands\Make\ClassMakeCommand;
 use Xefi\LaravelOSDD\Console\Commands\Make\ConfigMakeCommand;
 use Xefi\LaravelOSDD\Console\Commands\Make\ConsoleMakeCommand;
+use Xefi\LaravelOSDD\Console\Commands\Make\ControllerMakeCommand;
 use Xefi\LaravelOSDD\Console\Commands\Make\EnumMakeCommand;
 use Xefi\LaravelOSDD\Console\Commands\Make\EventMakeCommand;
 use Xefi\LaravelOSDD\Console\Commands\Make\ExceptionMakeCommand;
+use Xefi\LaravelOSDD\Console\Commands\Make\FactoryMakeCommand;
 use Xefi\LaravelOSDD\Console\Commands\Make\InterfaceMakeCommand;
 use Xefi\LaravelOSDD\Console\Commands\Make\JobMakeCommand;
 use Xefi\LaravelOSDD\Console\Commands\Make\ListenerMakeCommand;
 use Xefi\LaravelOSDD\Console\Commands\Make\MailMakeCommand;
 use Xefi\LaravelOSDD\Console\Commands\Make\MiddlewareMakeCommand;
+use Xefi\LaravelOSDD\Console\Commands\Make\MigrateMakeCommand;
+use Xefi\LaravelOSDD\Console\Commands\Make\ModelMakeCommand;
 use Xefi\LaravelOSDD\Console\Commands\Make\NotificationMakeCommand;
 use Xefi\LaravelOSDD\Console\Commands\Make\ObserverMakeCommand;
+use Xefi\LaravelOSDD\Console\Commands\Make\PolicyMakeCommand;
+use Xefi\LaravelOSDD\Console\Commands\Make\RequestMakeCommand;
 use Xefi\LaravelOSDD\Console\Commands\Make\ResourceMakeCommand;
 use Xefi\LaravelOSDD\Console\Commands\Make\RuleMakeCommand;
 use Xefi\LaravelOSDD\Console\Commands\Make\ScopeMakeCommand;
+use Xefi\LaravelOSDD\Console\Commands\Make\SeederMakeCommand;
+use Xefi\LaravelOSDD\Console\Commands\Make\ServiceProviderMakeCommand;
+use Xefi\LaravelOSDD\Console\Commands\Make\TestMakeCommand;
 use Xefi\LaravelOSDD\Console\Commands\Make\TraitMakeCommand;
 use Xefi\LaravelOSDD\Console\Commands\Make\ViewMakeCommand;
-use Xefi\LaravelOSDD\Console\Commands\LayerCommand;
 use Xefi\LaravelOSDD\Console\Commands\PhpunitCommand;
-use Xefi\LaravelOSDD\SeederRegistry;
 use Xefi\LaravelOSDD\Console\Commands\SeedCommand;
 use Xefi\LaravelOSDD\Console\Commands\StartCommand;
+use Xefi\LaravelOSDD\Layers\LayersCollection;
 
 class LaravelOSDDServiceProvider extends ServiceProvider
 {
-    /**
-     * Bootstrap any package services.
-     */
     public function boot(): void
     {
         if ($this->app->runningInConsole()) {
-            $this->commands([
-                LayerCommand::class,
-                StartCommand::class,
-                ControllerMakeCommand::class,
-                FactoryMakeCommand::class,
-                MigrateMakeCommand::class,
-                ModelMakeCommand::class,
-                PolicyMakeCommand::class,
-                RequestMakeCommand::class,
-                SeederMakeCommand::class,
-                ServiceProviderMakeCommand::class,
-                TestMakeCommand::class,
-                CastMakeCommand::class,
-                ChannelMakeCommand::class,
-                ClassMakeCommand::class,
-                ConfigMakeCommand::class,
-                ConsoleMakeCommand::class,
-                EnumMakeCommand::class,
-                EventMakeCommand::class,
-                ExceptionMakeCommand::class,
-                InterfaceMakeCommand::class,
-                JobMakeCommand::class,
-                ListenerMakeCommand::class,
-                MailMakeCommand::class,
-                MiddlewareMakeCommand::class,
-                NotificationMakeCommand::class,
-                ObserverMakeCommand::class,
-                ResourceMakeCommand::class,
-                RuleMakeCommand::class,
-                ScopeMakeCommand::class,
-                TraitMakeCommand::class,
-                ViewMakeCommand::class,
-                PhpunitCommand::class,
-                SeedCommand::class,
-            ]);
+            $this->registerCommands();
         }
 
-        $this->publishes([
-            __DIR__.'/../config/osdd.php' => config_path('osdd.php'),
-        ]);
+        $this->publishConfig();
+
+        $this->app->booted(function () {
+            if (in_array('tinker', $_SERVER['argv'] ?? [])) {
+                $this->registerTinkerAliases();
+            }
+        });
     }
 
-    /**
-     * Register any package services.
-     */
     public function register(): void
     {
-        $this->mergeConfigFrom(
-            __DIR__.'/../config/osdd.php', 'osdd'
-        );
+        $this->mergeConfigFrom(__DIR__.'/../config/osdd.php', 'osdd');
 
         $this->app->singleton(SeederRegistry::class, fn() => new SeederRegistry());
 
         $this->app->singleton(MigrateMakeCommand::class, function ($app) {
             return new MigrateMakeCommand($app['migration.creator'], $app['composer']);
         });
+    }
+
+    private function registerCommands(): void
+    {
+        $this->commands([
+            LayerCommand::class,
+            StartCommand::class,
+            PhpunitCommand::class,
+            SeedCommand::class,
+            CastMakeCommand::class,
+            ChannelMakeCommand::class,
+            ClassMakeCommand::class,
+            ConfigMakeCommand::class,
+            ConsoleMakeCommand::class,
+            ControllerMakeCommand::class,
+            EnumMakeCommand::class,
+            EventMakeCommand::class,
+            ExceptionMakeCommand::class,
+            FactoryMakeCommand::class,
+            InterfaceMakeCommand::class,
+            JobMakeCommand::class,
+            ListenerMakeCommand::class,
+            MailMakeCommand::class,
+            MiddlewareMakeCommand::class,
+            MigrateMakeCommand::class,
+            ModelMakeCommand::class,
+            NotificationMakeCommand::class,
+            ObserverMakeCommand::class,
+            PolicyMakeCommand::class,
+            RequestMakeCommand::class,
+            ResourceMakeCommand::class,
+            RuleMakeCommand::class,
+            ScopeMakeCommand::class,
+            SeederMakeCommand::class,
+            ServiceProviderMakeCommand::class,
+            TestMakeCommand::class,
+            TraitMakeCommand::class,
+            ViewMakeCommand::class,
+        ]);
+    }
+
+    private function publishConfig(): void
+    {
+        $this->publishes([
+            __DIR__.'/../config/osdd.php' => config_path('osdd.php'),
+        ]);
+    }
+
+    private function registerTinkerAliases(): void
+    {
+        [$namespaces, $map] = $this->buildLayerClassMap();
+
+        $this->app['config']->set('tinker.alias', array_merge(
+            $this->app['config']->get('tinker.alias', []),
+            $namespaces,
+        ));
+
+        spl_autoload_register(function (string $class) use ($map) {
+            if (str_contains($class, '\\') || ! isset($map[$class])) {
+                return;
+            }
+
+            require_once $map[$class]['path'];
+            class_alias($map[$class]['fqcn'], $class);
+        });
+    }
+
+    private function buildLayerClassMap(): array
+    {
+        $namespaces = [];
+        $map        = [];
+
+        foreach (LayersCollection::fromConfig() as $layer) {
+            $namespace = $layer->manifest->rootNamespace();
+            $srcPath   = rtrim($layer->manifest->srcPath($layer->path), '/\\');
+
+            $namespaces[] = $namespace;
+
+            if (! is_dir($srcPath)) {
+                continue;
+            }
+
+            foreach ((new Finder())->files()->name('*.php')->in($srcPath) as $file) {
+                $relative  = substr($file->getRealPath(), strlen($srcPath) + 1);
+                $fqcn      = $namespace . str_replace([DIRECTORY_SEPARATOR, '.php'], ['\\', ''], $relative);
+                $shortName = basename($relative, '.php');
+
+                $map[$shortName] ??= ['fqcn' => $fqcn, 'path' => $file->getRealPath()];
+            }
+        }
+
+        return [$namespaces, $map];
     }
 }

--- a/tests/LayerServiceProviderTest.php
+++ b/tests/LayerServiceProviderTest.php
@@ -107,4 +107,10 @@ class LayerServiceProviderTest extends TestCase
         $this->assertSame('value', $this->app['config']->get('brand-new.option'));
     }
 
+    public function testLayerAliasesAreNotRegisteredOutsideOfTinker(): void
+    {
+        // tinker is never in argv in this test class — aliases must stay empty
+        $this->assertNotContains('Functional\\TestLayer\\', $this->app['config']->get('tinker.alias', []));
+    }
+
 }

--- a/tests/TinkerLayerAliasTest.php
+++ b/tests/TinkerLayerAliasTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Xefi\LaravelOSDD\Tests;
+
+use Illuminate\Filesystem\Filesystem;
+
+class TinkerLayerAliasTest extends TestCase
+{
+    private string $tmpPath;
+
+    protected function getEnvironmentSetUp($app): void
+    {
+        $_SERVER['argv'][] = 'tinker';
+
+        $this->tmpPath = sys_get_temp_dir() . '/osdd-tinker-test-' . uniqid();
+
+        mkdir($this->tmpPath . '/functional/billing/src', 0755, true);
+
+        file_put_contents($this->tmpPath . '/functional/billing/composer.json', json_encode([
+            'name'     => 'functional/billing',
+            'type'     => 'layer',
+            'autoload' => ['psr-4' => ['Functional\\Billing\\' => 'src/']],
+        ]));
+
+        file_put_contents(
+            $this->tmpPath . '/functional/billing/src/Invoice.php',
+            "<?php\nnamespace Functional\\Billing;\nclass Invoice {}"
+        );
+
+        $app->setBasePath($this->tmpPath);
+        $app['config']->set('osdd.layers.paths', [
+            'functional' => $this->tmpPath . '/functional',
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        (new Filesystem)->deleteDirectory($this->tmpPath);
+
+        $_SERVER['argv'] = array_filter($_SERVER['argv'], fn($v) => $v !== 'tinker');
+    }
+
+    public function testLayerClassIsResolvableByShortName(): void
+    {
+        class_exists('Invoice');
+
+        $this->assertTrue(class_exists('Invoice'));
+    }
+
+    public function testLayerClassShortNameResolvesToCorrectFqcn(): void
+    {
+        class_exists('Invoice');
+
+        $this->assertSame('Functional\\Billing\\Invoice', (new \ReflectionClass('Invoice'))->getName());
+    }
+
+    public function testLayerNamespacesAreAddedToTinkerAlias(): void
+    {
+        $this->assertContains('Functional\\Billing\\', $this->app['config']->get('tinker.alias', []));
+    }
+
+}


### PR DESCRIPTION
Refactor LaravelOSDDServiceProvider: extract command registration and config publishing into private methods, and add tinker-specific alias registration during app boot. Introduces buildLayerClassMap (using LayersCollection and Symfony Finder) to collect layer namespaces and map short class names to their files, and registers an autoloader that requires files and class_alias()es short names to their FQCNs when tinker is detected. Update tests: ensure aliases are not registered outside tinker and add TinkerLayerAliasTest to verify short-name resolution and tinker.alias population.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Layer classes can now be referenced by short names when using Laravel Tinker, eliminating the need to type fully qualified class names.

* **Tests**
  * Added new test coverage for layer alias registration behavior.
  * Added verification that aliases are properly scoped to Tinker environments only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->