### PR TITLE
Remove interact override and add prompt test

### DIFF
--- a/src/Console/Commands/Make/ModelMakeCommand.php
+++ b/src/Console/Commands/Make/ModelMakeCommand.php
@@ -4,8 +4,6 @@ namespace Xefi\LaravelOSDD\Console\Commands\Make;
 
 use Illuminate\Support\Str;
 use Symfony\Component\Console\Attribute\AsCommand;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(name: 'osdd:model')]
 class ModelMakeCommand extends \Illuminate\Foundation\Console\ModelMakeCommand
@@ -18,11 +16,6 @@ class ModelMakeCommand extends \Illuminate\Foundation\Console\ModelMakeCommand
      * @var string
      */
     protected $name = 'osdd:model';
-
-    protected function interact(InputInterface $input, OutputInterface $output): void
-    {
-        $this->resolveLayer();
-    }
 
     protected function getStub(): string
     {

--- a/tests/Console/Commands/Make/ModelMakeCommandTest.php
+++ b/tests/Console/Commands/Make/ModelMakeCommandTest.php
@@ -52,6 +52,17 @@ class ModelMakeCommandTest extends TestCase
         $this->assertFilenameExists('functional/test-layer/src/Models/User.php');
     }
 
+    public function testItPromptsForNameWhenNotProvided(): void
+    {
+        $this->artisan('osdd:model')
+            ->expectsSearch('Which layer should this be generated in?', 'functional/test-layer', '', ['functional/test-layer' => 'functional/test-layer'])
+            ->expectsQuestion('What should the model be named?', 'User')
+            ->expectsChoice('Would you like any of the following?', [], ['seed' => 'Database Seeder', 'factory' => 'Factory', 'requests' => 'Form Requests', 'migration' => 'Migration', 'policy' => 'Policy', 'resource' => 'Resource Controller'])
+            ->assertExitCode(0);
+
+        $this->assertFilenameExists('functional/test-layer/src/Models/User.php');
+    }
+
     public function testItGeneratesNestedModelInCorrectPath(): void
     {
         $this->artisan('osdd:model', ['name' => 'Admin/User', '--layer' => 'functional/test-layer'])


### PR DESCRIPTION
Remove the interact() override and unused InputInterface/OutputInterface imports from ModelMakeCommand (layer resolution no longer handled there). Add testItPromptsForNameWhenNotProvided to assert the osdd:model command prompts for layer and model name when no name is given and generates the expected model file.

Closes #20 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the model generation command by removing custom interaction override, allowing it to use standard base behavior

* **Tests**
  * Added test coverage verifying the command prompts for model name and additional options when invoked without arguments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->