### PR TITLE
Sort layers when selecting layers options

### DIFF
--- a/src/Console/Commands/Make/ChoosesOsddLayer.php
+++ b/src/Console/Commands/Make/ChoosesOsddLayer.php
@@ -38,6 +38,7 @@ trait ChoosesOsddLayer
             options: fn(string $value) => $layers
                 ->filter(fn(Layer $l) => str_contains($l->manifest->name(), $value))
                 ->mapWithKeys(fn(Layer $l) => [$l->manifest->name() => $l->manifest->name()])
+                ->sort()
                 ->all(),
         );
 


### PR DESCRIPTION
Sort layers when we are selecting an existing layer in the `osdd:` commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Layer selection options in command prompts are now displayed in sorted order for improved usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->