### PR TITLE
Replace hyphens in plural snake names

### DIFF
--- a/src/Console/Commands/LayerCommand.php
+++ b/src/Console/Commands/LayerCommand.php
@@ -121,7 +121,7 @@ class LayerCommand extends Command
         $namespace   = $this->toNamespace($vendor, $package);
         $singular    = Str::singular(Str::studly($package));
         $pascal      = Str::studly($package);
-        $pluralSnake = (string) Str::of($package)->replace('-', '_')->pluralStudly()->snake();
+        $pluralSnake = Str::snake(Str::pluralStudly($pascal));
 
         // Create composer.json first — layer must be discoverable before make commands run
         $this->createFile(

--- a/src/Console/Commands/LayerCommand.php
+++ b/src/Console/Commands/LayerCommand.php
@@ -121,7 +121,7 @@ class LayerCommand extends Command
         $namespace   = $this->toNamespace($vendor, $package);
         $singular    = Str::singular(Str::studly($package));
         $pascal      = Str::studly($package);
-        $pluralSnake = Str::snake(Str::pluralStudly($package));
+        $pluralSnake = (string) Str::of($package)->replace('-', '_')->pluralStudly()->snake();
 
         // Create composer.json first — layer must be discoverable before make commands run
         $this->createFile(

--- a/tests/Console/Commands/LayerCommandTest.php
+++ b/tests/Console/Commands/LayerCommandTest.php
@@ -30,6 +30,7 @@ class LayerCommandTest extends TestCase
     {
         $this->app['files']->deleteDirectory($this->app->basePath('functional/my-layer'));
         $this->app['files']->deleteDirectory($this->app->basePath('functional/my-auth-layer'));
+        $this->app['files']->deleteDirectory($this->app->basePath('functional/external-accounts'));
         $this->app['files']->deleteDirectory($this->app->basePath('technical/my-layer'));
 
         if ($this->composerOriginal !== null) {
@@ -196,6 +197,21 @@ class LayerCommandTest extends TestCase
         $this->artisan('osdd:layer')
             ->expectsQuestion('Layer name', 'InvalidName')
             ->assertFailed();
+    }
+
+    public function testMigrationTableNameReplacesHyphensWithUnderscores(): void
+    {
+        $this->artisan('osdd:layer')
+            ->expectsQuestion('Layer name', 'external-accounts')
+            ->expectsChoice('Which generators should be run?', ['migration'], $this->allGenerators())
+            ->expectsConfirmation('Run composer update now?', 'no')
+            ->assertExitCode(0);
+
+        $files = glob($this->app->basePath('functional/external-accounts/database/migrations/*_create_external_accounts_table.php'));
+        $this->assertNotEmpty($files);
+
+        $contents = $this->app['files']->get($files[0]);
+        $this->assertStringContainsString("Schema::create('external_accounts'", $contents);
     }
 
     public function testNamespaceIsCorrectlyDerivedFromHyphenatedNames(): void


### PR DESCRIPTION
Ensure package names containing hyphens produce safe snake_case plural names by replacing '-' with '_' before calling pluralStudly()->snake() in LayerCommand. Add a test that generates a layer named "external-accounts" and asserts the migration file uses the table name external_accounts, and update test cleanup to remove the external-accounts directory.

closes #33 