### PR TITLE
Exclude layer migrations from PHPUnit coverage

### DIFF
--- a/src/Console/Commands/PhpunitCommand.php
+++ b/src/Console/Commands/PhpunitCommand.php
@@ -50,10 +50,17 @@ class PhpunitCommand extends Command
             return self::FAILURE;
         }
 
+        $changed = $this->excludeMigrationsFromCoverage($dom, $xpath);
+
         $layers = LayersCollection::fromConfig();
 
         if ($layers->isEmpty()) {
             $this->warn('No OSDD layers discovered.');
+
+            if ($changed) {
+                $this->laravel['files']->put($xmlPath, $dom->saveXML());
+                $this->info('phpunit.xml updated successfully.');
+            }
 
             return self::SUCCESS;
         }
@@ -90,11 +97,54 @@ class PhpunitCommand extends Command
             $added++;
         }
 
-        if ($added > 0) {
+        if ($added > 0 || $changed) {
             $this->laravel['files']->put($xmlPath, $dom->saveXML());
             $this->info('phpunit.xml updated successfully.');
         }
 
         return self::SUCCESS;
+    }
+
+    /**
+     * Ensure layer migrations are excluded from code coverage.
+     *
+     * Every OSDD layer ships its own database/migrations directory; those files
+     * are schema boilerplate and must not count towards coverage metrics.
+     *
+     * @return bool whether the document was modified
+     */
+    private function excludeMigrationsFromCoverage(DOMDocument $dom, DOMXPath $xpath): bool
+    {
+        $migrationsPath = '**/database/migrations';
+
+        $alreadyExcluded = $xpath
+            ->query('//source/exclude/directory[normalize-space()="' . $migrationsPath . '"]')
+            ->item(0);
+
+        if ($alreadyExcluded) {
+            return false;
+        }
+
+        $source = $xpath->query('//source')->item(0);
+
+        if (!$source) {
+            $source = $dom->createElement('source');
+            $dom->documentElement->appendChild($source);
+        }
+
+        $exclude = $xpath->query('//source/exclude')->item(0);
+
+        if (!$exclude) {
+            $exclude = $dom->createElement('exclude');
+            $source->appendChild($exclude);
+        }
+
+        $directory = $dom->createElement('directory', $migrationsPath);
+        $directory->setAttribute('suffix', '.php');
+        $exclude->appendChild($directory);
+
+        $this->info("Excluded <comment>{$migrationsPath}</comment> from code coverage.");
+
+        return true;
     }
 }

--- a/tests/Console/Commands/PhpunitCommandTest.php
+++ b/tests/Console/Commands/PhpunitCommandTest.php
@@ -95,6 +95,38 @@ class PhpunitCommandTest extends TestCase
         $this->app['files']->deleteDirectory($layerPath);
     }
 
+    public function testItExcludesLayerMigrationsFromCoverage(): void
+    {
+        $this->artisan('osdd:phpunit')->assertExitCode(0);
+
+        $xml = $this->app['files']->get($this->xmlPath);
+        $dom = new \DOMDocument();
+        $dom->loadXML($xml);
+
+        $xpath = new \DOMXPath($dom);
+        $directory = $xpath
+            ->query('//source/exclude/directory[normalize-space()="**/database/migrations"]')
+            ->item(0);
+
+        $this->assertNotNull($directory);
+        $this->assertSame('.php', $directory->getAttribute('suffix'));
+    }
+
+    public function testItDoesNotDuplicateTheMigrationsExclusion(): void
+    {
+        $this->artisan('osdd:phpunit')->assertExitCode(0);
+        $this->artisan('osdd:phpunit')->assertExitCode(0);
+
+        $xml = $this->app['files']->get($this->xmlPath);
+        $dom = new \DOMDocument();
+        $dom->loadXML($xml);
+
+        $xpath = new \DOMXPath($dom);
+        $directories = $xpath->query('//source/exclude/directory[normalize-space()="**/database/migrations"]');
+
+        $this->assertSame(1, $directories->length);
+    }
+
     public function testItFailsWhenPhpunitXmlIsMissing(): void
     {
         $this->app['files']->delete($this->xmlPath);


### PR DESCRIPTION
Ensure every OSDD layer's database/migrations directory is excluded from code coverage by adding a '**/database/migrations' <directory> exclusion to phpunit.xml. The PhpunitCommand now persists the updated xml even when no layers are discovered and logs an info message when the exclusion is added. Added tests to verify the exclusion is created and not duplicated.

closes #30 