### PR TITLE
Preserve App PSR-4; only remove DB mappings

### DIFF
--- a/resources/boost/skills/laravel-osdd/SKILL.md
+++ b/resources/boost/skills/laravel-osdd/SKILL.md
@@ -14,7 +14,7 @@ Use this skill whenever `xefi/laravel-osdd` is in the project's `composer.json`.
 - **Never** create files under `app/`, `database/migrations/`, `database/seeders/`, `database/factories/`, or root `config/`. Those directories do not exist in an OSDD project.
 - **Never** run a vanilla `make:*` command (`make:model`, `make:migration`, `make:controller`, …). Always use the `osdd:*` equivalent, which targets a specific layer.
 - **Never** edit `bootstrap/providers.php` to register a domain provider. Layer service providers are auto-registered via each layer's `composer.json` (`extra.laravel.providers`).
-- **Never** add a `psr-4` entry for `App\\`, `Database\\Factories\\` or `Database\\Seeders\\` to the root `composer.json`. `osdd:start` strips them on purpose.
+- **Never** add a `psr-4` entry for `Database\\Factories\\` or `Database\\Seeders\\` to the root `composer.json`. `osdd:start` strips them on purpose. The `App\\` mapping is kept so Laravel can still resolve an application namespace, but no code should live under `app/`.
 
 ## Features
 

--- a/src/Console/Commands/StartCommand.php
+++ b/src/Console/Commands/StartCommand.php
@@ -140,7 +140,11 @@ class StartCommand extends Command
 
         $composer = json_decode($this->files->get($composerPath), true, 512, JSON_THROW_ON_ERROR);
 
-        foreach (['App\\', 'Database\\Factories\\', 'Database\\Seeders\\'] as $key) {
+        // Keep the `App\` mapping so Laravel can still detect an application
+        // namespace (getNamespace() otherwise throws once app/ is gone). Only
+        // the database factory/seeder namespaces are dropped — those live in
+        // layers under OSDD.
+        foreach (['Database\\Factories\\', 'Database\\Seeders\\'] as $key) {
             unset($composer['autoload']['psr-4'][$key]);
             unset($composer['autoload-dev']['psr-4'][$key]);
         }

--- a/tests/Console/Commands/StartCommandTest.php
+++ b/tests/Console/Commands/StartCommandTest.php
@@ -317,9 +317,13 @@ class StartCommandTest extends TestCase
         $composer = json_decode(file_get_contents($this->projectPath . '/composer.json'), true);
 
         $psr4 = $composer['autoload']['psr-4'] ?? [];
-        $this->assertArrayNotHasKey('App\\', $psr4);
         $this->assertArrayNotHasKey('Database\\Factories\\', $psr4);
         $this->assertArrayNotHasKey('Database\\Seeders\\', $psr4);
+
+        // The App\ mapping is kept so Laravel can still detect the application
+        // namespace once app/ is deleted.
+        $this->assertArrayHasKey('App\\', $psr4);
+        $this->assertSame('app/', $psr4['App\\']);
     }
 
     public function testItAsksForComposerUpdateConfirmation(): void


### PR DESCRIPTION
Keep the App\\ (PSR-4) mapping in composer.json so Laravel can still detect the application namespace after app/ is removed; only strip Database\\Factories\\ and Database\\Seeders\\ mappings. Update StartCommand to stop removing App\\ and adjust tests to assert App\\ remains (and maps to 'app/'). Update SKILL.md to reflect that App\\ is retained and that no code should live under app/ in OSDD projects.

closes #34