### PR TITLE
Add layer source paths to ide-helper.model_locations

### DIFF
--- a/src/LaravelOSDDServiceProvider.php
+++ b/src/LaravelOSDDServiceProvider.php
@@ -50,8 +50,14 @@ class LaravelOSDDServiceProvider extends ServiceProvider
         $this->publishConfig();
 
         $this->app->booted(function () {
-            if (in_array('tinker', $_SERVER['argv'] ?? [])) {
+            $argv = $_SERVER['argv'] ?? [];
+
+            if (in_array('tinker', $argv)) {
                 $this->registerTinkerAliases();
+            }
+
+            if (in_array('ide-helper:models', $argv)) {
+                $this->registerIdeHelperModelLocations();
             }
         });
     }
@@ -130,6 +136,27 @@ class LaravelOSDDServiceProvider extends ServiceProvider
             require_once $map[$class]['path'];
             class_alias($map[$class]['fqcn'], $class);
         });
+    }
+
+    private function registerIdeHelperModelLocations(): void
+    {
+        $config = $this->app['config'];
+
+        if (! $config->has('ide-helper.model_locations')) {
+            return;
+        }
+
+        $locations = $config->get('ide-helper.model_locations', []);
+
+        foreach (LayersCollection::fromConfig() as $layer) {
+            $srcPath = rtrim($layer->manifest->srcPath($layer->path), '/\\');
+
+            if (is_dir($srcPath)) {
+                $locations[] = $srcPath;
+            }
+        }
+
+        $config->set('ide-helper.model_locations', array_values(array_unique($locations)));
     }
 
     private function buildLayerClassMap(): array

--- a/tests/IdeHelperModelLocationsTest.php
+++ b/tests/IdeHelperModelLocationsTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Xefi\LaravelOSDD\Tests;
+
+use Illuminate\Filesystem\Filesystem;
+
+class IdeHelperModelLocationsTest extends TestCase
+{
+    private string $tmpPath;
+
+    protected function getEnvironmentSetUp($app): void
+    {
+        $_SERVER['argv'][] = 'ide-helper:models';
+
+        $this->tmpPath = sys_get_temp_dir() . '/osdd-ide-helper-test-' . uniqid();
+
+        mkdir($this->tmpPath . '/functional/billing/src/Models', 0755, true);
+
+        file_put_contents($this->tmpPath . '/functional/billing/composer.json', json_encode([
+            'name'     => 'functional/billing',
+            'type'     => 'layer',
+            'autoload' => ['psr-4' => ['Functional\\Billing\\' => 'src/']],
+        ]));
+
+        $app->setBasePath($this->tmpPath);
+        $app['config']->set('osdd.layers.paths', [
+            'functional' => $this->tmpPath . '/functional',
+        ]);
+
+        // Simulate barryvdh/laravel-ide-helper being installed with its default config.
+        $app['config']->set('ide-helper.model_locations', ['app']);
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        (new Filesystem)->deleteDirectory($this->tmpPath);
+
+        $_SERVER['argv'] = array_filter($_SERVER['argv'], fn($v) => $v !== 'ide-helper:models');
+    }
+
+    public function testLayerSourcePathIsAddedToModelLocations(): void
+    {
+        $locations = $this->app['config']->get('ide-helper.model_locations', []);
+
+        $this->assertContains($this->tmpPath . '/functional/billing/src', $locations);
+    }
+
+    public function testExistingModelLocationsArePreserved(): void
+    {
+        $locations = $this->app['config']->get('ide-helper.model_locations', []);
+
+        $this->assertContains('app', $locations);
+    }
+}


### PR DESCRIPTION
Register layer source directories when running the ide-helper:models command. The service provider now detects the ide-helper:models argv and merges existing ide-helper.model_locations with any layer src paths (ensuring directories exist and deduplicating). Added registerIdeHelperModelLocations() to collect paths from LayersCollection and update config. Also added IdeHelperModelLocationsTest to verify layer src is added and existing locations are preserved.

closes #40 